### PR TITLE
Fix participant auto-join issue: show join modal for participants

### DIFF
--- a/public/js/room.js
+++ b/public/js/room.js
@@ -136,10 +136,12 @@ class PlanningPokerRoom {
         
         let name = urlParams.get('name');
         let competence = urlParams.get('competence');
-
-        if (!name || !competence) {
+        
+        const isCreator = localStorage.getItem('session_id') && urlParams.has('name') && urlParams.has('competence');
+        
+        if (!isCreator || !name || !competence) {
             document.getElementById('joinName').value = name || '';
-            document.getElementById('joinCompetence').value = competence || 'Fullstack';
+            document.getElementById('joinCompetence').value = competence || 'Frontend';
             document.getElementById('joinModal').classList.remove('hidden');
             
             document.getElementById('joinRoomBtn').onclick = () => {


### PR DESCRIPTION
# Fix participant auto-join issue: show join modal for participants

## Summary
This PR fixes a critical user onboarding bug where participants accessing shared room links were automatically joining with the room creator's name and competence instead of seeing the join modal to enter their own information.

**Root Cause**: The `joinRoom()` function logic was checking only for the presence of URL parameters (`name` and `competence`) to decide whether to show the join modal. Since room creators are redirected with these parameters after room creation, participants accessing the same shared link were also auto-joining.

**Solution**: Modified the logic to distinguish between room creators and participants by checking for a combination of localStorage `session_id` and URL parameters. Only room creators (who have both) should auto-join, while participants should always see the join modal.

## Review & Testing Checklist for Human
- [ ] **Test room creator flow**: Create a new room and verify you're automatically redirected to the room without seeing a join modal
- [ ] **Test participant flow**: Share a room link with someone else (or use incognito/different browser) and verify the join modal appears
- [ ] **Test edge cases**: Clear browser localStorage, try multiple tabs, test in different browsers to ensure session logic works correctly
- [ ] **Verify join modal functionality**: Ensure participants can successfully enter their name and competence and join the room
- [ ] **Test session persistence**: Verify that room creators maintain their session across page refreshes and browser tabs

**Recommended Test Plan**: 
1. Create room as admin → verify auto-join works
2. Copy room link → open in incognito/different browser → verify join modal appears
3. Fill out join modal → verify successful room entry with correct participant info
4. Test with cleared browser data to ensure no false positives for creator detection

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    User["User Browser"] --> RoomURL["Room URL Access"]
    RoomURL --> RoomJS["public/js/room.js"]
    RoomJS --> JoinRoom["joinRoom() Function"]
    
    JoinRoom --> CreatorCheck["Check: session_id + URL params"]
    CreatorCheck --> IsCreator["Room Creator"]
    CreatorCheck --> IsParticipant["Participant"]
    
    IsCreator --> AutoJoin["Auto-join Room"]
    IsParticipant --> JoinModal["Show Join Modal"]
    JoinModal --> RoomHTML["public/room.html"]
    
    AutoJoin --> Server["server.js"]
    JoinModal --> Server
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
    
    class RoomJS,JoinRoom,CreatorCheck major-edit
    class RoomHTML,Server context
```

### Notes
- The fix adds a new `isCreator` boolean that combines localStorage session_id check with URL parameter presence
- Default competence changed from 'Fullstack' to 'Frontend' to match the create room form default
- This change only affects the client-side joining logic; server-side room joining remains unchanged
- The fix maintains backward compatibility - existing room creators will continue to work normally

**Link to Devin run**: https://app.devin.ai/sessions/f05711cfaa154289b44af1cd12b56075  
**Requested by**: @st53182