### PR TITLE
Fix participant joining: clean modal and shared links

### DIFF
--- a/public/js/room.js
+++ b/public/js/room.js
@@ -16,11 +16,11 @@ class PlanningPokerRoom {
 
     initializeEventListeners() {
         document.getElementById('copyLinkBtn').addEventListener('click', () => {
-            const link = window.location.href;
-            navigator.clipboard.writeText(link).then(() => {
+            const baseUrl = window.location.origin + window.location.pathname;
+            navigator.clipboard.writeText(baseUrl).then(() => {
                 this.showToast('Ссылка на комнату скопирована!', 'success');
             }).catch(() => {
-                this.showToast(`Поделитесь этой ссылкой: ${link}`, 'info');
+                this.showToast(`Поделитесь этой ссылкой: ${baseUrl}`, 'info');
             });
         });
 
@@ -140,8 +140,8 @@ class PlanningPokerRoom {
         const isCreator = localStorage.getItem('session_id') && urlParams.has('name') && urlParams.has('competence');
         
         if (!isCreator || !name || !competence) {
-            document.getElementById('joinName').value = name || '';
-            document.getElementById('joinCompetence').value = competence || 'Frontend';
+            document.getElementById('joinName').value = '';
+            document.getElementById('joinCompetence').value = 'Frontend';
             document.getElementById('joinModal').classList.remove('hidden');
             
             document.getElementById('joinRoomBtn').onclick = () => {


### PR DESCRIPTION
# Fix participant joining: clean modal and shared links

## Summary
Fixes the participant auto-join issue where participants accessing shared room links were automatically joining with the room creator's name and competence instead of seeing a modal to enter their own information.

**Root Cause**: The `joinRoom()` function was pre-filling the participant modal with URL parameters from the creator, and the copy link button was sharing URLs with creator credentials embedded.

**Solution**: 
- Modified `joinRoom()` function to show clean modal (empty fields) for participants instead of pre-filling with creator's URL parameters
- Updated copy link functionality to generate clean URLs without creator parameters

## Review & Testing Checklist for Human
- [ ] **Test complete participant joining flow on production** - Create room, copy link, open in incognito/different browser, verify modal shows empty fields
- [ ] **Verify creator auto-join still works** - Create room as creator, confirm no modal appears and auto-join works
- [ ] **Test copy link functionality** - Verify copied URLs are clean (no name/competence parameters)
- [ ] **Test edge cases** - Malformed URLs, missing parameters, direct navigation to room URLs
- [ ] **Multi-participant testing** - Multiple participants joining same room with different credentials

**Recommended Test Plan**: 
1. Create room on production → verify creator auto-joins
2. Copy room link → verify URL is clean (no parameters)  
3. Open link in incognito → verify modal appears with empty fields
4. Fill modal with different name/competence → verify successful join
5. Test multiple participants joining same room

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["public/js/room.js"]:::major-edit --> B["joinRoom()"]:::major-edit
    A --> C["initializeEventListeners()"]:::major-edit
    
    B --> D["Creator Detection Logic"]:::context
    B --> E["Modal Pre-filling Logic"]:::major-edit
    
    C --> F["Copy Link Button"]:::major-edit
    F --> G["URL Generation"]:::major-edit
    
    H["URL Parameters"]:::context --> B
    I["localStorage session_id"]:::context --> B
    
    J["Participant Modal"]:::context --> E
    K["Clipboard/Share"]:::context --> G
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- **Changes affect core user flow** - participant joining is fundamental functionality
- **Local testing confirmed fix works** but production testing still needed
- **Creator auto-join functionality preserved** - only participant experience changed
- **Socket communication unchanged** - only client-side modal and URL generation logic modified

**Link to Devin run**: https://app.devin.ai/sessions/f05711cfaa154289b44af1cd12b56075  
**Requested by**: @st53182