### PR TITLE
Fix participant joining validation error

### DIFF
--- a/public/js/room.js
+++ b/public/js/room.js
@@ -48,9 +48,6 @@ class PlanningPokerRoom {
             this.submitVote();
         });
 
-        document.getElementById('joinRoomBtn').addEventListener('click', () => {
-            this.joinRoom();
-        });
 
         document.getElementById('dismissError').addEventListener('click', () => {
             document.getElementById('errorToast').classList.add('hidden');


### PR DESCRIPTION
Fixes the validation error that prevented participants from entering their name in the join modal.

## Problem
Participants were getting validation error 'Пожалуйста, введите ваше имя' (Please enter your name) even after entering their name in the join modal.

## Root Cause
There were two conflicting event handlers for the joinRoomBtn:
1. Line 52: Event listener that calls joinRoom() which clears the name field
2. Line 147: Onclick handler that tries to read the now-empty field

## Solution
- Removed the conflicting event listener in initializeEventListeners()
- Maintains single onclick handler set up in joinRoom() function
- Preserves creator auto-join functionality while fixing participant joining

## Testing
✅ Tested locally - participants can now enter name and join successfully
✅ Creator auto-join still works correctly
✅ Modal appears with empty fields for participants
✅ Validation passes when name is entered

**Link to Devin run**: https://app.devin.ai/sessions/f05711cfaa154289b44af1cd12b56075
**Requested by**: @st53182