### PR TITLE
Add login/registration buttons to room interface for unauthenticated users

### DIFF
--- a/public/js/room.js
+++ b/public/js/room.js
@@ -638,6 +638,10 @@ class PlanningPokerRoom {
         
         if (token && user) {
             document.getElementById('dashboardBtn').classList.remove('hidden');
+            const authLinks = document.getElementById('authLinks');
+            if (authLinks) {
+                authLinks.classList.add('hidden');
+            }
             
             if (this.isAdmin && this.roomData && !this.roomData.owner_id) {
                 const claimBtn = document.getElementById('claimRoomBtn');
@@ -652,6 +656,10 @@ class PlanningPokerRoom {
             }
         } else {
             document.getElementById('dashboardBtn').classList.add('hidden');
+            const authLinks = document.getElementById('authLinks');
+            if (authLinks) {
+                authLinks.classList.remove('hidden');
+            }
             const claimBtn = document.getElementById('claimRoomBtn');
             if (claimBtn) {
                 claimBtn.classList.add('hidden');

--- a/public/room.html
+++ b/public/room.html
@@ -55,6 +55,11 @@
                 </div>
                 
                 <div class="flex items-center space-x-4">
+                    <div id="authLinks" class="flex items-center space-x-4">
+                        <a href="/login" class="text-gray-600 hover:text-blue-600 transition-colors">Войти</a>
+                        <a href="/register" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors">Регистрация</a>
+                    </div>
+                    
                     <a 
                         id="dashboardBtn" 
                         href="/dashboard"


### PR DESCRIPTION
# Add login/registration buttons to room interface for unauthenticated users

## Summary
This PR adds login and registration buttons to the room interface header for unauthenticated users, enabling them to authenticate directly from within an anonymous room. This is a critical piece of the room claiming functionality - users can now create anonymous rooms, share them, and then register/login later to claim ownership if they are admins.

**Key Changes:**
- Added `authLinks` div with login/registration buttons to `room.html` header
- Updated `checkAuthenticationStatus()` in `room.js` to show/hide authentication buttons based on user state
- Buttons are hidden when user is authenticated (showing dashboard/claim buttons instead)
- Enables complete workflow: anonymous room → login from room → claim room

## Review & Testing Checklist for Human
- [ ] **End-to-end workflow testing**: Create anonymous room → click login button → authenticate → verify claim button appears → successfully claim room
- [ ] **Authentication state transitions**: Verify buttons appear/disappear correctly when logging in/out from room interface
- [ ] **UI/responsive design**: Check that new buttons don't break layout on desktop/mobile screens
- [ ] **Production testing**: Test complete workflow on production URL after merge (local testing was limited due to credential issues)

**Recommended Test Plan:**
1. Navigate to production site as unauthenticated user
2. Create anonymous room and verify login/registration buttons appear in room header
3. Click login button → complete authentication → return to room
4. Verify login buttons are hidden and claim/dashboard buttons are visible
5. Test room claiming functionality works end-to-end

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    RoomHTML["public/room.html<br/>Room Interface"]:::major-edit
    RoomJS["public/js/room.js<br/>Room Logic"]:::major-edit
    AuthPages["Login/Register Pages"]:::context
    Database["Database<br/>Room Claiming"]:::context
    
    RoomHTML --> RoomJS
    RoomJS --> AuthPages
    AuthPages --> Database
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- Local testing confirmed buttons appear correctly for unauthenticated users
- Could not complete full authentication workflow locally due to credential issues
- This change is essential for the room claiming feature to work properly
- Production testing is critical before considering this complete

**Link to Devin run**: https://app.devin.ai/sessions/f05711cfaa154289b44af1cd12b56075  
**Requested by**: @st53182