### PR TITLE
Fix participant counter to show only connected participants

### DIFF
--- a/public/js/room.js
+++ b/public/js/room.js
@@ -675,7 +675,10 @@ class PlanningPokerRoom {
         const container = document.getElementById('participantsList');
         const count = document.getElementById('participantsCount');
         
-        count.textContent = this.participants.length;
+        const connectedParticipants = this.participants.filter(participant => 
+            this.connectedParticipantIds && this.connectedParticipantIds.includes(participant.id)
+        );
+        count.textContent = connectedParticipants.length;
         
         if (this.participants.length === 0) {
             container.innerHTML = '<p class="text-gray-500 text-center py-8">Пока нет участников.</p>';


### PR DESCRIPTION
# Fix participant counter to show only connected participants

## Summary

Fixed a UI inconsistency where the participant counter displayed the total number of participants from the database (6) while the participant list only showed connected participants (2). The counter now accurately reflects the number of participants actually displayed in the UI.

**Root cause**: The counter was using `this.participants.length` (all participants) while the display logic filtered to only show connected participants using `this.connectedParticipantIds`.

**Solution**: Modified the counter logic to filter participants the same way as the display logic, ensuring the counter matches what users actually see.

## Review & Testing Checklist for Human

⚠️ **Medium Priority - UI Logic & Real-time Behavior**

- [ ] **End-to-end testing**: Join a room with multiple participants from different browser tabs/devices, then close some tabs and verify the counter immediately updates to match the displayed participant count
- [ ] **Edge case verification**: Test counter behavior during initial page load, reconnections, and when `connectedParticipantIds` might be null/undefined
- [ ] **Real-time updates**: Verify the counter updates in real-time as participants join/leave without requiring page refresh

**Recommended test plan:**
1. Open the production URL in 4-5 browser tabs with different participant names
2. Join the same room from all tabs  
3. Close 2-3 tabs and verify counter decreases immediately
4. Rejoin from some tabs and verify counter increases
5. Confirm counter always matches the number of participants visible in the list

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Client["Browser Client<br/>room.js"]:::major-edit
    WebSocket["WebSocket Events<br/>server.js"]:::context
    Database["Database<br/>database.js"]:::context
    UI["Participant List UI<br/>HTML Display"]:::context
    
    WebSocket -->|"participants_updated<br/>connectedParticipantIds"| Client
    Client -->|"updateParticipantsList()"| UI
    Client -->|"filter by<br/>connectedParticipantIds"| UI
    Client -->|"count connected<br/>participants only"| Counter["Participant Counter<br/>(6) -> (2)"]:::major-edit
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Link to Devin run:** https://app.devin.ai/sessions/af384b040432456c8df12e77425f13cb

**Requested by:** @st53182

**Risk assessment:** 🟡 Medium - Simple logic change but depends on existing WebSocket infrastructure for maintaining `connectedParticipantIds`. The fix addresses a clear UI inconsistency but needs verification that real-time updates work correctly.

**Files changed:**
- `public/js/room.js`: Modified `updateParticipantsList()` to count only connected participants instead of all participants from database