### PR TITLE
Fix participant counter inconsistency with automatic duplicate cleanup

### DIFF
--- a/public/js/room.js
+++ b/public/js/room.js
@@ -222,6 +222,11 @@ class PlanningPokerRoom {
             this.updateParticipantsList();
             this.showToast(`Участник ${data.participant_name} был удален из комнаты`, 'info');
         });
+
+        this.socket.on('participants_list_updated', (data) => {
+            this.participants = data.participants;
+            this.updateParticipantsList();
+        });
     }
 
     joinRoom() {

--- a/server.js
+++ b/server.js
@@ -41,7 +41,8 @@ const {
   claimRoom,
   deleteRoom,
   updateParticipantAdminStatus,
-  removeParticipant
+  removeParticipant,
+  cleanupDuplicateParticipants
 } = require('./database');
 
 const app = express();
@@ -504,6 +505,16 @@ io.on('connection', (socket) => {
       io.to(room.id).emit('participants_updated', { 
         connected_participant_ids: connectedParticipants 
       });
+      
+      const cleanupResult = await cleanupDuplicateParticipants(room.id);
+      if (cleanupResult.cleanedCount > 0) {
+        console.log(`Cleaned up ${cleanupResult.cleanedCount} duplicate participants in room ${room.id}`);
+        
+        const updatedRoom = await getRoomById(room.id);
+        io.to(room.id).emit('participants_list_updated', { 
+          participants: updatedRoom.participants 
+        });
+      }
       
     } catch (error) {
       socket.emit('error', { message: error.message });


### PR DESCRIPTION
# Fix participant counter inconsistency with automatic duplicate cleanup

## Summary

This PR implements automatic duplicate participant detection and cleanup to resolve inconsistencies where different users see different participant counts in the same room. The solution runs cleanup whenever someone connects to a room, making it self-healing.

**Key Changes:**
- Added `cleanupDuplicateParticipants()` function that detects participants with identical name+competence combinations and removes duplicates while preserving admin status and oldest entries
- Integrated cleanup into the `join_room_by_link` socket handler to run automatically on every connection
- Added client-side socket listener to refresh participant lists when duplicates are cleaned
- Optimized SQL query to minimize performance impact for parallel usage

**Approach:** Rather than fixing WebSocket timing issues, this addresses the root cause (duplicate data) by automatically cleaning it up whenever participants connect.

## Review & Testing Checklist for Human

This PR has **medium-high risk** due to inability to test locally and performance implications. Please verify:

- [ ] **Test duplicate cleanup functionality** - Manually create duplicate participants in database, then connect to room and verify duplicates are automatically removed
- [ ] **Verify admin status preservation** - Ensure admin participants are kept when duplicates exist (query prioritizes `is_admin DESC, joined_at ASC`)
- [ ] **Test performance impact** - Check connection speed with cleanup enabled, especially with multiple concurrent users joining
- [ ] **Verify UI consistency** - Open room in multiple browser tabs, refresh one tab, ensure participant counts remain consistent across all tabs
- [ ] **Test race conditions** - Have multiple participants join simultaneously to verify no conflicts occur during cleanup

**Recommended Test Plan:**
1. Create test room with duplicate participants (same name+competence)
2. Join room from multiple browser tabs
3. Verify duplicates are cleaned and counts are consistent
4. Test admin scenarios and concurrent joining

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    Client["public/js/room.js<br/>Socket Listeners"]:::minor-edit
    Server["server.js<br/>join_room_by_link Handler"]:::minor-edit
    Database["database.js<br/>cleanupDuplicateParticipants()"]:::major-edit
    PostgreSQL[("PostgreSQL<br/>participants table")]:::context
    
    Client -->|"socket.on('join_room_by_link')"| Server
    Server -->|"await joinRoom()"| Database
    Server -->|"await cleanupDuplicateParticipants()"| Database
    Database -->|"DELETE duplicates"| PostgreSQL
    Server -->|"emit('participants_list_updated')"| Client
    Client -->|"updateParticipantsList()"| Client

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- **Performance consideration**: User mentioned many teams will use this in parallel - the cleanup query uses `GROUP BY` with `array_agg()` which could be expensive on large participant tables
- **Unable to test locally**: PostgreSQL database wasn't available during development, so end-to-end testing is required
- **Self-healing approach**: This solution automatically fixes inconsistencies rather than preventing them, making it more robust than timing-based fixes

**Link to Devin run**: https://app.devin.ai/sessions/1ff04840436548c180282bc40a1d4e04  
**Requested by**: @st53182 (artjoms.grinakins@gmail.com)