### PR TITLE
Force re-authentication after page refresh to fix participant sync

### DIFF
--- a/public/js/room.js
+++ b/public/js/room.js
@@ -249,21 +249,15 @@ class PlanningPokerRoom {
             return;
         }
         
-        const storedName = localStorage.getItem('participant_name');
-        const storedCompetence = localStorage.getItem('participant_competence');
-        const sessionId = localStorage.getItem('session_id');
+        localStorage.removeItem('participant_name');
+        localStorage.removeItem('participant_competence');
+        localStorage.removeItem('session_id');
         
-        const isCreator = sessionId && urlParams.has('name') && urlParams.has('competence');
-        const hasStoredSession = storedName && storedCompetence && sessionId;
+        const isCreator = urlParams.has('name') && urlParams.has('competence');
         
-        if (!isCreator && !name && !competence && hasStoredSession) {
-            name = storedName;
-            competence = storedCompetence;
-            document.getElementById('joinModal').classList.add('hidden');
-            this.performJoin(encryptedLink, name, competence);
-        } else if (!isCreator || !name || !competence) {
-            document.getElementById('joinName').value = storedName || '';
-            document.getElementById('joinCompetence').value = storedCompetence || 'Frontend';
+        if (!isCreator && !name && !competence) {
+            document.getElementById('joinName').value = '';
+            document.getElementById('joinCompetence').value = 'Frontend';
             document.getElementById('joinModal').classList.remove('hidden');
             
             document.getElementById('joinRoomBtn').onclick = () => {
@@ -274,9 +268,6 @@ class PlanningPokerRoom {
                     this.showError('Пожалуйста, введите ваше имя');
                     return;
                 }
-                
-                localStorage.setItem('participant_name', name);
-                localStorage.setItem('participant_competence', competence);
                 
                 document.getElementById('joinModal').classList.add('hidden');
                 this.performJoin(encryptedLink, name, competence);


### PR DESCRIPTION
# Force re-authentication after page refresh to fix participant sync

## Summary
Resolves the persistent participant synchronization bug by implementing a fundamental change to session management: **users must now re-enter their name and competence after every page refresh**. This eliminates the root cause of participant count inconsistencies and display synchronization issues.

**Key Changes:**
- **Breaking Change**: Complete removal of automatic session restoration from localStorage
- **Frontend**: Clear participant data (name, competence, session_id) on every page load
- **Server**: Include `connected_participant_ids` in `room_joined` event for immediate synchronization
- **UX**: Always show join modal after refresh (except for URL parameter flows)

**Impact**: This is a **breaking change** that fundamentally alters user experience - participants can no longer rely on automatic session restoration and must manually re-authenticate on every page refresh.

## Review & Testing Checklist for Human
- [ ] **Critical - User Experience Impact**: Test the forced re-authentication flow extensively. Is requiring name/competence re-entry on every refresh too disruptive for normal usage patterns?
- [ ] **Critical - Real Multi-User Testing**: Test with 3+ real users from different devices/networks (not browser tabs) joining and refreshing simultaneously to verify synchronization works and no race conditions exist
- [ ] **High Priority - Authentication Edge Cases**: Test all authentication scenarios: URL parameters (`?name=X&competence=Y`), authenticated users, anonymous users, and network interruption scenarios
- [ ] **Medium Priority - Regression Testing**: Verify normal user workflows (join, vote, leave, admin actions) still work correctly and localStorage clearing doesn't break other functionality
- [ ] **Medium Priority - Load Testing**: Test with 5+ concurrent users to ensure the synchronization fix scales properly under load

**Recommended Test Plan:**
1. Open room with multiple real users from different devices/networks
2. Have users refresh pages simultaneously and individually  
3. Verify participant count remains accurate in all scenarios
4. Test URL parameter flows (`?name=TestUser&competence=Frontend`)
5. Test authenticated vs anonymous user flows
6. Verify admin status and permissions work correctly
7. Test user acceptance of forced re-authentication UX

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    Server["server.js<br/>(Socket event handlers)"]:::major-edit
    Frontend["public/js/room.js<br/>(joinRoom & handleRoomJoined)"]:::major-edit
    Database["database.js<br/>(Transaction logic)"]:::context
    LocalStorage["localStorage<br/>(Session data)"]:::major-edit
    JoinModal["Join Modal<br/>(Authentication UI)"]:::minor-edit

    Frontend -->|"clears on every page load"| LocalStorage
    Frontend -->|"always shows after refresh"| JoinModal
    Server -->|"room_joined + connected_participant_ids"| Frontend
    Database -->|"participant data"| Server
    Frontend -->|"join_room_by_link event"| Server

    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- **Breaking Change Warning**: This completely changes user session behavior - users lose automatic session restoration
- **Production Testing**: Changes were tested on poker.growboard.ru but only with single-user scenarios
- **Alternative Approaches**: Could have implemented smarter session merging, but forced re-auth provides the cleanest state management
- **Deployment**: Should auto-deploy via Render.com after merge, but verify deployment status
- **Rollback Plan**: If UX impact is too severe, can revert to previous session restoration logic and explore alternative synchronization fixes

**Link to Devin run**: https://app.devin.ai/sessions/deb86ecb3872433abb1c6dc5467f58a3  
**Requested by**: @st53182