### PR TITLE
Remove admin-only restrictions for voting/story selection and fix English translations

### DIFF
--- a/database.js
+++ b/database.js
@@ -517,17 +517,6 @@ async function updateRoomCurrentStory(roomId, storyId) {
   }
 }
 
-async function makeParticipantAdmin(participantId) {
-  const client = await pool.connect();
-  try {
-    await client.query(
-      'UPDATE participants SET is_admin = true WHERE id = $1',
-      [participantId]
-    );
-  } finally {
-    client.release();
-  }
-}
 
 async function claimRoom(encryptedLink, userId) {
   const client = await pool.connect();
@@ -909,7 +898,6 @@ module.exports = {
   updateStoryVotingState,
   updateStoryFinalEstimate,
   updateRoomCurrentStory,
-  makeParticipantAdmin,
   clearStoryVotes,
   getRoomById,
   createUser,

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -150,11 +150,13 @@
                     <p class="text-gray-600 text-sm mb-4">Создана: ${createdDate}</p>
                     <div class="flex space-x-2">
                         <a href="/room/${room.encrypted_link}?from_dashboard=true" 
-                           class="flex-1 bg-blue-600 text-white text-center py-2 px-4 rounded-md hover:bg-blue-700 transition-colors text-sm">
+                           class="flex-1 bg-blue-600 text-white text-center py-2 px-4 rounded-md hover:bg-blue-700 transition-colors text-sm"
+                           data-translate="dashboard.enter_as_admin">
                             Войти как админ
                         </a>
                         <button onclick="copyRoomLink('${room.encrypted_link}')" 
-                                class="bg-gray-100 text-gray-700 py-2 px-4 rounded-md hover:bg-gray-200 transition-colors text-sm">
+                                class="bg-gray-100 text-gray-700 py-2 px-4 rounded-md hover:bg-gray-200 transition-colors text-sm"
+                                data-translate="dashboard.copy_link">
                             Копировать ссылку
                         </button>
                     </div>
@@ -173,9 +175,11 @@
         function copyRoomLink(encryptedLink) {
             const url = `${window.location.origin}/room/${encryptedLink}`;
             navigator.clipboard.writeText(url).then(() => {
-                showToast('Ссылка скопирована в буфер обмена');
+                const message = window.translationManager ? window.translationManager.t('dashboard.link_copied') : 'Ссылка скопирована в буфер обмена';
+                showToast(message);
             }).catch(() => {
-                showToast('Не удалось скопировать ссылку', 'error');
+                const message = window.translationManager ? window.translationManager.t('dashboard.copy_failed') : 'Не удалось скопировать ссылку';
+                showToast(message, 'error');
             });
         }
 

--- a/server.js
+++ b/server.js
@@ -30,7 +30,6 @@ const {
   updateStoryVotingState,
   updateStoryFinalEstimate,
   updateRoomCurrentStory,
-  makeParticipantAdmin,
   clearStoryVotes,
   getRoomById,
   createUser,
@@ -619,17 +618,6 @@ io.on('connection', (socket) => {
     }
   });
   
-  socket.on('make_admin', async (data) => {
-    try {
-      const { room_id, target_participant_id, participant_id } = data;
-      
-      await makeParticipantAdmin(target_participant_id);
-      
-      io.to(room_id).emit('admin_promoted', { participant_id: target_participant_id });
-    } catch (error) {
-      socket.emit('error', { message: error.message });
-    }
-  });
 
   socket.on('update_story', async (data) => {
     try {


### PR DESCRIPTION
# Remove admin-only restrictions for voting/story selection and fix English translations

## Summary

This PR democratizes the planning poker process by removing admin-only restrictions for starting votes and selecting stories, while keeping admin rights only for participant removal and room ownership. Additionally, it fixes missing English translations in the dashboard where hardcoded Russian text was appearing.

**Key Changes:**
- **Frontend (`public/js/room.js`)**: Removed `makeAdmin` function, admin checks from `setCurrentStory` and `updateVotingState`, and make-admin UI elements
- **Backend (`server.js`)**: Removed `make_admin` socket handler and related imports
- **Database (`database.js`)**: Removed `makeParticipantAdmin` function entirely
- **Dashboard (`public/dashboard.html`)**: Added proper translation keys for "Enter as Admin" and "Copy Link" buttons

## Review & Testing Checklist for Human

- [ ] **Multi-participant voting test**: Create a room, join with multiple non-admin participants, verify they can start voting and select stories for estimation
- [ ] **Admin removal functionality**: Verify admin can still remove participants from the room but the "make admin" button is completely gone
- [ ] **English translation verification**: Switch to English language and confirm dashboard buttons display in English (not Russian)
- [ ] **UI/UX flow review**: Check that the planning poker workflow makes sense without make-admin functionality 
- [ ] **Socket communication test**: Verify real-time updates work correctly when non-admins control voting/story selection

**Recommended test plan**: Create a room as admin, invite 2-3 participants, have non-admin participants start votes and select different stories while admin observes. Switch language to English and verify translations.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph Frontend
        RoomJS["public/js/room.js<br/>Major permission changes"]:::major-edit
        DashHTML["public/dashboard.html<br/>Translation fixes"]:::minor-edit
        TransEN["public/translations/en.json<br/>Contains EN translations"]:::context
    end
    
    subgraph Backend
        ServerJS["server.js<br/>Removed make_admin handler"]:::major-edit
        DatabaseJS["database.js<br/>Removed makeParticipantAdmin"]:::major-edit
    end
    
    RoomJS -->|"Socket events"| ServerJS
    ServerJS -->|"Database calls"| DatabaseJS
    DashHTML -->|"Uses translations"| TransEN
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB  
classDef context fill:#FFFFFF
```

### Notes

**⚠️ Testing Limitation**: Local testing was limited due to database connection issues in the development environment. The frontend loads correctly and language switching works, but full multi-user scenarios need to be tested in a proper environment.

**Permission Model**: The new model allows all participants to control the planning poker flow (voting, story selection) while maintaining admin control over participant management and room ownership.

---

**Requested by**: artjoms.grinakins@gmail.com (@st53182)  
**Link to Devin run**: https://app.devin.ai/sessions/0e56216cc0a94239a0b8ec0e9bc20227