### PR TITLE
Fix database foreign key constraint violation when entering rooms from dashboard

### DIFF
--- a/database.js
+++ b/database.js
@@ -273,6 +273,8 @@ async function joinRoom(encryptedLink, name, competence, sessionId, userId = nul
     const room = roomResult.rows[0];
     
     if (userId) {
+      await client.query('UPDATE stories SET created_by = NULL WHERE created_by IN (SELECT id FROM participants WHERE room_id = $1 AND user_id = $2)', [room.id, userId]);
+      
       await client.query(`
         DELETE FROM participants 
         WHERE room_id = $1 AND user_id = $2


### PR DESCRIPTION
# Fix database foreign key constraint violation when entering rooms from dashboard

## Summary

Fixes the database constraint violation error `"update or delete on table 'participants' violates foreign key constraint 'stories_created_by_fkey' on table 'stories'"` that occurs when users enter rooms from the dashboard.

**Root Cause**: The `joinRoom` function was deleting participants by `user_id` without properly handling the foreign key constraint between `stories.created_by` and `participants.id`.

**Solution**: Added constraint handling logic to update `stories.created_by = NULL` before deleting participants, following the same pattern used in `removeParticipant` and `cleanupDuplicateParticipants` functions.

## Review & Testing Checklist for Human

- [ ] **Test room entry from dashboard** - Verify that entering rooms from poker.growboard.ru dashboard no longer produces constraint violation errors
- [ ] **Verify SQL subquery correctness** - Review the SQL logic `UPDATE stories SET created_by = NULL WHERE created_by IN (SELECT id FROM participants WHERE room_id = $1 AND user_id = $2)` to ensure it targets only the intended participant records
- [ ] **Test complete room workflow** - Verify voting, story creation, and admin functions still work correctly after the database fix
- [ ] **Check error handling** - Test error scenarios to ensure proper transaction rollback behavior
- [ ] **Verify performance impact** - Ensure room joining performance remains acceptable with the additional UPDATE query

**Recommended Test Plan**: 
1. Log into poker.growboard.ru with provided credentials
2. Navigate to dashboard and attempt to enter existing rooms
3. Create stories, start voting, and test admin functions
4. Monitor browser console for any database errors

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Dashboard["public/dashboard.html<br/>User clicks enter room"]:::context
    RoomJS["public/js/room.js<br/>joinRoom() function"]:::context
    ServerJS["server.js<br/>join_room_by_link handler"]:::context
    DatabaseJS["database.js<br/>joinRoom() function"]:::major-edit
    
    Dashboard --> RoomJS
    RoomJS --> ServerJS
    ServerJS --> DatabaseJS
    
    DatabaseJS --> UpdateStories["UPDATE stories SET created_by = NULL<br/>(NEW: constraint handling)"]:::major-edit
    DatabaseJS --> DeleteParticipants["DELETE FROM participants<br/>(existing logic)"]:::context
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes


- This fix follows the established pattern used in other participant deletion functions (`removeParticipant`, `cleanupDuplicateParticipants`)
- The constraint violation specifically occurred during dashboard room entry because this triggers `joinRoom` with a `userId`, causing participant cleanup
- All other instances of `DELETE FROM participants` in the codebase already have proper constraint handling
- **Critical**: This fix was not fully tested locally due to connection issues, so production testing is essential

---
**Link to Devin run**: https://app.devin.ai/sessions/0e56216cc0a94239a0b8ec0e9bc20227  
**Requested by**: @st53182