### PR TITLE
Fix voting logic: prevent selectVote when section is hidden

### DIFF
--- a/public/js/room.js
+++ b/public/js/room.js
@@ -160,6 +160,8 @@ class PlanningPokerRoom {
                 this.currentStory.voting_state = 'voting';
                 this.updateVotingState();
                 this.resetVotingState();
+                this.generateVotingCards();
+                this.selectedVote = null;
             }
         });
 
@@ -364,6 +366,12 @@ class PlanningPokerRoom {
     selectVote(value) {
         this.selectedVote = value;
         
+        const votingSection = document.getElementById('votingSection');
+        if (votingSection && votingSection.classList.contains('hidden')) {
+            console.warn('Voting section is hidden - cannot select vote yet');
+            return;
+        }
+        
         const selectedVoteElement = document.getElementById('selectedVoteValue');
         const submitVoteBtn = document.getElementById('submitVoteBtn');
         
@@ -377,8 +385,11 @@ class PlanningPokerRoom {
             card.classList.add('border-gray-200');
         });
         
-        event.target.closest('.voting-card').classList.add('selected', 'border-blue-500', 'bg-blue-50');
-        event.target.closest('.voting-card').classList.remove('border-gray-200');
+        const clickedCard = event?.target?.closest('.voting-card');
+        if (clickedCard) {
+            clickedCard.classList.add('selected', 'border-blue-500', 'bg-blue-50');
+            clickedCard.classList.remove('border-gray-200');
+        }
         
         selectedVoteElement.textContent = value;
         submitVoteBtn.classList.remove('hidden');


### PR DESCRIPTION
# Fix voting logic: prevent selectVote when section is hidden

## Summary

Fixes a critical voting functionality bug where clicking on voting cards would throw errors when the admin starts voting but the voting section hasn't become visible yet. The issue occurred because `selectVote()` attempted to access DOM elements (`selectedVoteElement`, `submitVoteBtn`) that were inside a hidden voting section.

**Key Changes:**
- Added visibility check in `selectVote()` to prevent errors when voting section is hidden
- Improved event handling for clicked card selection using optional chaining
- Enhanced `voting_started` socket handler to properly reset state and generate cards
- Added defensive programming to handle race conditions between admin actions and UI updates

## Review & Testing Checklist for Human

**⚠️ High Priority Items (3):**

- [ ] **End-to-end voting flow testing**: Test complete voting workflow with multiple users in different browsers/tabs to verify the timing fix works correctly. Admin starts voting → users see cards → users can click and select → submit works properly.

- [ ] **Event object availability**: Verify that `event?.target?.closest('.voting-card')` works correctly in the `selectVote` context. The code assumes `event` is available in global scope when cards are clicked.

- [ ] **Race condition testing**: Test rapid admin actions like starting/stopping voting, switching between stories, and interrupting votes to ensure no edge cases cause errors or inconsistent UI state.

**Recommended Test Plan:**
1. Open app in 2+ browser tabs (simulate admin + participants)
2. Create room, add story, start voting as admin
3. Verify voting cards appear for all participants without console errors
4. Test clicking cards and submitting votes
5. Test admin interrupting vote by selecting different story
6. Repeat with rapid actions to test timing edge cases

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Admin["👤 Admin User"] 
    StartBtn["'Start Voting' Button"]
    SocketServer["🔗 Socket Server"]
    VotingStarted["voting_started event"]
    UpdateState["updateVotingState()"]
    GenerateCards["generateVotingCards()"]
    SelectVote["selectVote()"]
    VotingSection["#votingSection DOM"]
    VotingCards["Voting Cards UI"]
    
    Admin --> StartBtn
    StartBtn --> SocketServer
    SocketServer --> VotingStarted
    VotingStarted --> UpdateState
    VotingStarted --> GenerateCards
    UpdateState --> VotingSection
    GenerateCards --> VotingCards
    VotingCards --> SelectVote
    SelectVote --> VotingSection
    
    SelectVote:::major-edit
    VotingStarted:::major-edit
    UpdateState:::context
    GenerateCards:::context
    VotingSection:::context
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes


**⚠️ Testing Limitation:** Due to database connection issues during development, this fix was not fully tested end-to-end with multiple users. The changes are based on code analysis and understanding of the error, but real-world multi-user testing is essential.

**Technical Details:**
- The original error occurred because `selectVote()` was called immediately when cards were clicked, but the voting section might still be hidden due to async state updates
- Added `votingSection.classList.contains('hidden')` check as an early return condition
- Enhanced socket handler to ensure proper initialization sequence: state update → reset → card generation

**Session Info:**
- **Requested by:** @st53182  
- **Devin Session:** https://app.devin.ai/sessions/f944a783e28f49a1a049c083d6538544