### PR TITLE
Fix competency popup bug for authenticated non-administrators

### DIFF
--- a/public/js/room.js
+++ b/public/js/room.js
@@ -239,7 +239,7 @@ class PlanningPokerRoom {
         const authToken = localStorage.getItem('auth_token');
         const userInfo = localStorage.getItem('user_info');
         
-        if (authToken && userInfo && fromDashboard) {
+        if (authToken && userInfo) {
             const user = JSON.parse(userInfo);
             name = user.name;
             
@@ -286,15 +286,6 @@ class PlanningPokerRoom {
                 };
                 return;
             }
-        }
-        
-        if (authToken && userInfo && !name && !competence) {
-            const user = JSON.parse(userInfo);
-            name = user.name;
-            competence = 'Fullstack'; // Default competence for authenticated users
-            document.getElementById('joinModal').classList.add('hidden');
-            this.performJoin(encryptedLink, name, competence);
-            return;
         }
         
         if (!authToken) {


### PR DESCRIPTION
# Fix competency popup bug for authenticated non-administrators

## Summary

Fixed a critical bug where authenticated non-administrator users were automatically joining rooms with "Fullstack" competency instead of seeing the competency selection popup. The issue was caused by a fallback condition in the `joinRoom()` function that bypassed room ownership checks for users not coming from the dashboard.

**Key Changes:**
- Removed `&& fromDashboard` condition so ALL authenticated users go through room ownership verification
- Deleted problematic fallback logic (lines 291-298) that auto-assigned "Fullstack" competency
- Preserved admin functionality: room owners still join directly, non-owners see popup

## Review & Testing Checklist for Human

**🔴 Critical - Must Test:**
- [ ] **Admin Functionality Preserved**: Verify room owners/admins can still join rooms directly without seeing popup (test with `artem@onagile.ru`)
- [ ] **Bug Fix Works**: Verify non-administrator users now see competency selection popup when joining rooms they don't own (test with `1212@12.ru`)
- [ ] **Production Testing**: Test on `poker.growboard.ru` with the room URL `31a4e6a84d306d6d5d83d44808a0ab78` using both provided accounts
- [ ] **Error Handling**: Test network failure scenarios by blocking API requests in browser DevTools - users should still see popup as fallback
- [ ] **Console Errors**: Check browser console for JavaScript errors during all test scenarios

**Recommended Test Plan:**
1. Login as `artem@onagile.ru` on production and join a room you own - should join directly
2. Login as `1212@12.ru` and join the same room - should see competency popup
3. Test error scenarios by blocking `/api/user/rooms` in DevTools - should fallback to popup
4. Verify selected competency is properly applied after joining

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
flowchart TD
    RoomJS["public/js/room.js<br/>joinRoom() function"]:::major-edit
    UserRooms["/api/user/rooms<br/>API endpoint"]:::context
    RoomHTML["public/room.html<br/>competency modal"]:::context
    
    RoomJS -->|"Checks ownership"| UserRooms
    UserRooms -->|"Returns user's rooms"| RoomJS
    RoomJS -->|"Shows popup for non-owners"| RoomHTML
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#F5F5F5
```

### Notes

- **Root Cause**: The fallback condition `if (authToken && userInfo && !name && !competence)` was automatically assigning "Fullstack" to any authenticated user who accessed a room directly (not via dashboard)
- **Fix Strategy**: Extended room ownership checking to ALL authenticated users, not just those from dashboard
- **Backward Compatibility**: Room owners maintain existing behavior (direct join), only non-owners see the new popup
- **Error Handling**: API failures now properly fallback to showing the competency popup instead of auto-assigning "Fullstack"

**Session Info:**
- Requested by: @st53182 (artjoms.grinakins@gmail.com)
- Link to Devin run: https://app.devin.ai/sessions/1b51ba2f8198433f9446047027a81a0a