### PR TITLE
Fix delete button translation and positioning on dashboard

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -141,6 +141,7 @@
                 
                 const estimationType = room.estimation_type === 'story_points' ? 'SP' : 'H';
                 const createdDate = new Date(room.created_at).toLocaleDateString('ru-RU');
+                const deleteButtonText = window.translationManager ? window.translationManager.t('dashboard.delete_room') : 'Удалить';
                 
                 roomCard.innerHTML = `
                     <div class="flex items-start justify-between mb-4">
@@ -148,21 +149,22 @@
                         <span class="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">${estimationType}</span>
                     </div>
                     <p class="text-gray-600 text-sm mb-4"> ${createdDate}</p>
-                    <div class="flex space-x-2">
-                        <a href="/room/${room.encrypted_link}?from_dashboard=true" 
-                           class="flex-1 bg-blue-600 text-white text-center py-2 px-4 rounded-md hover:bg-blue-700 transition-colors text-sm"
-                           data-translate="dashboard.enter_as_admin">
-                            Войти как админ
-                        </a>
-                        <button onclick="copyRoomLink('${room.encrypted_link}')" 
-                                class="bg-gray-100 text-gray-700 py-2 px-4 rounded-md hover:bg-gray-200 transition-colors text-sm"
-                                data-translate="dashboard.copy_link">
-                            Копировать ссылку
-                        </button>
+                    <div class="space-y-2">
+                        <div class="flex space-x-2">
+                            <a href="/room/${room.encrypted_link}?from_dashboard=true" 
+                               class="flex-1 bg-blue-600 text-white text-center py-2 px-4 rounded-md hover:bg-blue-700 transition-colors text-sm"
+                               data-translate="dashboard.enter_as_admin">
+                                Войти как админ
+                            </a>
+                            <button onclick="copyRoomLink('${room.encrypted_link}')" 
+                                    class="bg-gray-100 text-gray-700 py-2 px-4 rounded-md hover:bg-gray-200 transition-colors text-sm"
+                                    data-translate="dashboard.copy_link">
+                                Копировать ссылку
+                            </button>
+                        </div>
                         <button onclick="deleteRoomFromDashboard('${room.id}', '${escapeHtml(room.name)}')" 
-                                class="bg-red-100 text-red-700 py-2 px-4 rounded-md hover:bg-red-200 transition-colors text-sm"
-                                data-translate="dashboard.delete_room">
-                            Удалить
+                                class="w-full bg-red-100 text-red-700 py-2 px-4 rounded-md hover:bg-red-200 transition-colors text-sm">
+                            ${deleteButtonText}
                         </button>
                     </div>
                 `;


### PR DESCRIPTION
# Fix delete button translation and positioning on dashboard

## Summary

Fixes two issues with delete buttons on the dashboard page:

1. **Translation display bug**: Delete buttons were showing the translation key "dashboard.delete_room" instead of the actual translated text ("Удалить комнату" in Russian, "Delete Room" in English)
2. **Button positioning**: Repositioned delete buttons to appear in a separate row under the "Войти как админ" and "Копировать ссылку" buttons instead of inline with them

**Root cause**: The translation system's `updatePageContent()` method only processes elements that exist in the DOM when it's called. Since room cards are created dynamically after page load, the `data-translate` attributes on delete buttons were never processed.

**Solution**: Replace `data-translate` approach with direct `window.translationManager.t()` calls in the template, following the same pattern used elsewhere in the codebase (e.g., `copyRoomLink` function).

## Review & Testing Checklist for Human

- [ ] **Visual verification**: Confirm delete buttons appear in a separate row under admin/copy buttons and look visually appealing
- [ ] **Translation functionality**: Test language switching (RU/EN) and verify delete buttons show correct translated text in both languages  
- [ ] **Delete functionality**: Verify delete buttons still work correctly (confirm dialog, actual deletion, room list refresh)
- [ ] **Responsive design**: Check layout works properly on mobile/tablet screen sizes
- [ ] **Edge case testing**: Test with slow network to ensure translation manager loads before room cards are created

**Recommended test plan**: 
1. Log into production dashboard at https://poker.growboard.ru/dashboard
2. Create a few test rooms if needed
3. Verify delete button layout and translations
4. Test language switching and delete functionality
5. Test on mobile device/responsive view

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Dashboard["public/dashboard.html<br/>(displayRooms function)"]:::major-edit
    TranslationManager["public/js/translations.js<br/>(TranslationManager.t method)"]:::context
    RuJson["public/translations/ru.json<br/>(dashboard.delete_room key)"]:::context
    EnJson["public/translations/en.json<br/>(dashboard.delete_room key)"]:::context
    
    Dashboard -->|"calls t() method"| TranslationManager
    TranslationManager -->|"reads translation"| RuJson
    TranslationManager -->|"reads translation"| EnJson
    
    Dashboard -->|"creates room cards with<br/>deleteButtonText variable"| RoomCard["Room Card HTML<br/>(delete button)"]:::minor-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- This PR addresses the issue reported by @st53182 where delete buttons displayed translation keys instead of proper text
- Changes follow existing patterns in the codebase for dynamic translation calls
- **Risk**: Limited local testing due to authentication issues - production testing is essential
- **Risk**: Translation timing dependency - assumes `window.translationManager` is available when room cards are created
- Fallback behavior provides Russian text if translation manager fails to load

**Link to Devin run**: https://app.devin.ai/sessions/1b51ba2f8198433f9446047027a81a0a  
**Requested by**: @st53182