### PR TITLE
Fix delete button translation keys - use room.delete_room

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -141,7 +141,7 @@
                 
                 const estimationType = room.estimation_type === 'story_points' ? 'SP' : 'H';
                 const createdDate = new Date(room.created_at).toLocaleDateString('ru-RU');
-                const deleteButtonText = window.translationManager ? window.translationManager.t('dashboard.delete_room') : 'Удалить';
+                const deleteButtonText = window.translationManager ? window.translationManager.t('room.delete_room') : 'Удалить';
                 
                 roomCard.innerHTML = `
                     <div class="flex items-start justify-between mb-4">
@@ -207,7 +207,7 @@
 
         async function deleteRoomFromDashboard(roomId, roomName) {
             const confirmMessage = window.translationManager ? 
-                window.translationManager.t('dashboard.confirm_delete').replace('{roomName}', roomName) : 
+                window.translationManager.t('room.confirm_delete').replace('{roomName}', roomName) : 
                 `Вы уверены, что хотите удалить комнату "${roomName}"? Это действие нельзя отменить.`;
             
             if (!confirm(confirmMessage)) {


### PR DESCRIPTION
# Fix delete button translation keys - use room.delete_room

## Summary

Fixes the issue where delete buttons on the dashboard were displaying "dashboard.delete_room" instead of properly translated text ("Delete Room" in English, "Удалить комнату" in Russian). 

The root cause was incorrect translation key paths - the code was looking for `dashboard.delete_room` and `dashboard.confirm_delete`, but these keys actually exist in the `room` section of the translation files as `room.delete_room` and `room.confirm_delete`.

**Changes made:**
- Updated delete button text lookup from `dashboard.delete_room` → `room.delete_room`
- Updated confirmation dialog from `dashboard.confirm_delete` → `room.confirm_delete`

This was verified via browser console testing where `room.delete_room` correctly returns "Delete Room" while `dashboard.delete_room` returns the untranslated key.

## Review & Testing Checklist for Human

- [ ] **Critical**: Verify delete buttons now display proper translated text in both Russian ("Удалить комнату") and English ("Delete Room") 
- [ ] **Critical**: Test language switching (RU/EN toggle) to ensure delete button text updates correctly
- [ ] **Important**: Test delete functionality end-to-end - click delete button, verify confirmation dialog shows translated text, and confirm room deletion works
- [ ] **Important**: Check for any console errors or translation-related issues

**Recommended test plan**: 
1. Login to https://poker.growboard.ru/dashboard with `artem@onagile.ru` / `12345678`
2. Verify delete buttons show translated text, not "dashboard.delete_room" 
3. Switch between RU and EN languages and confirm button text updates
4. Try deleting a test room to verify confirmation dialog and functionality

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["dashboard.html<br/>(Delete Button Creation)"]:::major-edit --> B["translationManager.t()<br/>(Translation Lookup)"]:::context
    B --> C["room.delete_room<br/>(Correct Key Path)"]:::major-edit
    B --> D["dashboard.delete_room<br/>(Incorrect Key Path)"]:::context
    
    E["translations/en.json<br/>(Translation File)"]:::context --> F["room.delete_room: 'Delete Room'"]:::context
    E --> G["dashboard section<br/>(No delete_room key)"]:::context
    
    H["translations/ru.json<br/>(Translation File)"]:::context --> I["room.delete_room: 'Удалить комнату'"]:::context
    
    C --> E
    C --> H
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Testing limitation**: Local testing was blocked by authentication issues, so the fix needs verification on production
- **Translation key discovery**: Used browser console to confirm `room.delete_room` returns correct translations while `dashboard.delete_room` returns the key itself
- **Related PRs**: This follows PRs #53-56 which implemented delete button functionality and positioning fixes
- **Risk level**: Medium - affects user-facing text but change is straightforward key path correction

**Link to Devin run**: https://app.devin.ai/sessions/1b51ba2f8198433f9446047027a81a0a  
**Requested by**: @st53182 (artjoms.grinakins@gmail.com)