### PR TITLE
Fix delete button language switching - add data-translate attributes

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -141,8 +141,6 @@
                 
                 const estimationType = room.estimation_type === 'story_points' ? 'SP' : 'H';
                 const createdDate = new Date(room.created_at).toLocaleDateString('ru-RU');
-                const deleteButtonText = window.translationManager ? window.translationManager.t('room.delete_room') : 'Удалить';
-                
                 roomCard.innerHTML = `
                     <div class="flex items-start justify-between mb-4">
                         <h3 class="text-lg font-semibold text-gray-900 truncate">${escapeHtml(room.name)}</h3>
@@ -163,14 +161,20 @@
                             </button>
                         </div>
                         <button onclick="deleteRoomFromDashboard('${room.id}', '${escapeHtml(room.name)}')" 
-                                class="w-full bg-red-100 text-red-700 py-2 px-4 rounded-md hover:bg-red-200 transition-colors text-sm">
-                            ${deleteButtonText}
+                                class="w-full bg-red-100 text-red-700 py-2 px-4 rounded-md hover:bg-red-200 transition-colors text-sm"
+                                data-translate="room.delete_room">
+                            Удалить комнату
                         </button>
                     </div>
                 `;
                 
                 roomsList.appendChild(roomCard);
             });
+            
+            // Update translations for newly created elements
+            if (window.translationManager) {
+                window.translationManager.updatePageContent();
+            }
         }
 
         function escapeHtml(text) {


### PR DESCRIPTION
# Fix delete button language switching - add data-translate attributes

## Summary

Fixes the issue where delete buttons on the dashboard showed correct translated text on initial page load but did not update when users switched between Russian and English languages without refreshing the page.

**Root cause**: Delete buttons were created using direct `window.translationManager.t()` calls without `data-translate` attributes, so the translation system's `updatePageContent()` method couldn't find and update them during language switching.

**Changes made**:
- Added `data-translate="room.delete_room"` attribute to delete buttons
- Removed dynamic `deleteButtonText` variable in favor of the data-translate pattern
- Added `updatePageContent()` call after creating room cards to ensure translations are applied
- Set default button text to "Удалить комнату" (Russian) as fallback

## Review & Testing Checklist for Human

- [ ] **Critical**: Test language switching end-to-end - switch from EN to RU and back, verify delete buttons update text without page refresh
- [ ] **Critical**: Verify delete buttons show correct translated text in both languages ("Delete Room" in English, "Удалить комнату" in Russian)
- [ ] **Important**: Test delete functionality still works properly - click delete button, verify confirmation dialog, and confirm room deletion works
- [ ] **Important**: Check browser console for any translation-related errors or warnings

**Recommended test plan**: 
1. Login to https://poker.growboard.ru/dashboard with `artem@onagile.ru` / `12345678`
2. Verify delete buttons show translated text (should be "Delete Room" by default)
3. Switch to Russian language using the language switcher - delete buttons should immediately change to "Удалить комнату"
4. Switch back to English - delete buttons should change back to "Delete Room"
5. Try deleting a test room to verify the confirmation dialog and functionality works

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["dashboard.html<br/>(Delete Button Creation)"]:::major-edit --> B["data-translate attribute<br/>(room.delete_room)"]:::major-edit
    A --> C["updatePageContent()<br/>(After room cards created)"]:::major-edit
    
    D["translations.js<br/>(Translation Manager)"]:::context --> E["updatePageContent()<br/>(Updates data-translate elements)"]:::context
    E --> B
    
    F["Language Switcher<br/>(User clicks RU/EN)"]:::context --> G["setLanguage()<br/>(Triggers updatePageContent)"]:::context
    G --> E
    
    H["en.json / ru.json<br/>(Translation Files)"]:::context --> I["room.delete_room<br/>(Translation Keys)"]:::context
    I --> B

    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Testing limitation**: Local testing was blocked by authentication issues, so production testing is essential
- **Translation pattern**: This change aligns delete buttons with the existing data-translate pattern used by other UI elements
- **Default text**: Chose Russian as the default fallback text to match the existing pattern in the codebase
- **Risk level**: Medium - affects user-facing text but change follows established translation patterns

**Link to Devin run**: https://app.devin.ai/sessions/1b51ba2f8198433f9446047027a81a0a  
**Requested by**: @st53182 (artjoms.grinakins@gmail.com)