### PR TITLE
Fix voting counter to show only connected participants

### DIFF
--- a/server.js
+++ b/server.js
@@ -574,8 +574,15 @@ socket.on('start_voting', async (data) => {
         await submitVote(story_id, participant_id, participant.name, participant.competence, points);
         
         const storyVotes = await getStoryVotes(story_id);
-        const participantsResult = await client.query('SELECT COUNT(*) FROM participants WHERE room_id = $1', [room_id]);
-        const participantCount = parseInt(participantsResult.rows[0].count);
+        
+        const connectedParticipants = [];
+        for (const [participantId, socketId] of connectedUsers.entries()) {
+          const participantSocket = io.sockets.sockets.get(socketId);
+          if (participantSocket && participantSocket.room_id === room_id) {
+            connectedParticipants.push(participantId);
+          }
+        }
+        const participantCount = connectedParticipants.length;
         
         io.to(room_id).emit('vote_submitted', { vote_count: storyVotes.length, participant_count: participantCount });
       } finally {


### PR DESCRIPTION
# Fix voting counter to show only connected participants

## Summary

Fixed a bug where the voting counter displayed an incorrect participant count (e.g., showing "2/5" when only 2 participants were actually connected). The issue occurred because the previous implementation counted all participants who had ever joined the room from the database, rather than only those currently connected via WebSocket.

**Changes:**
- Replaced database query `SELECT COUNT(*) FROM participants WHERE room_id = $1` with logic that counts only connected participants
- Now uses the existing `connectedUsers` Map to filter participants by active socket connections in the specific room
- Matches the pattern already used in `disconnect` and `remove_participant` handlers

## Review & Testing Checklist for Human

**⚠️ CRITICAL: This change was not tested locally due to database connection issues**

- [ ] **Verify core functionality**: Test that voting counter shows correct number (e.g., 2/2 instead of 2/5) when some participants are disconnected
- [ ] **Test edge cases**: Disconnect participants during active voting and verify counter updates correctly  
- [ ] **Multi-room isolation**: Ensure participants in different rooms don't affect each other's counts
- [ ] **Race condition testing**: Rapidly connect/disconnect participants while voting is active

**Recommended test plan:**
1. Create a room with 3+ participants
2. Start voting, verify counter shows correct total (e.g., "1/3")
3. Close browser tabs for some participants (don't use logout)
4. Submit more votes, verify counter now shows reduced total (e.g., "2/2")
5. Repeat across multiple rooms simultaneously

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["server.js<br/>(submit_vote handler)"]:::major-edit --> B["connectedUsers Map<br/>(tracks active sockets)"]:::context
    A --> C["room.html<br/>(displays counter)"]:::context
    C --> D["room.js<br/>(receives updates)"]:::context
    
    E["Database<br/>(participants table)"]:::context -.-> A
    A --> F["Socket.IO emit<br/>(vote_submitted event)"]:::context
    F --> D
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This fix aligns the server-side counting logic with the frontend display logic (which already correctly shows only connected participants)
- The new approach reuses the existing `connectedUsers` Map pattern used elsewhere in the codebase
- **Risk**: Unable to test locally due to PostgreSQL connection issues - manual testing in deployed environment is essential

---

**Link to Devin run:** https://app.devin.ai/sessions/c7fbe4311f7e463c94826d3331c059cf  
**Requested by:** @st53182